### PR TITLE
Fix comment: tabs replaced by spaces

### DIFF
--- a/wavenet_model.py
+++ b/wavenet_model.py
@@ -132,7 +132,7 @@ class WaveNetModel(nn.Module):
 
             #            |----------------------------------------|     *residual*
             #            |                                        |
-            #            |	  |-- conv -- tanh --|			      |
+            #            |    |-- conv -- tanh --|                |
             # -> dilate -|----|                  * ----|-- 1x1 -- + -->	*input*
             #                 |-- conv -- sigm --|     |
             #                                         1x1

--- a/wavenet_model.py
+++ b/wavenet_model.py
@@ -130,13 +130,13 @@ class WaveNetModel(nn.Module):
         # WaveNet layers
         for i in range(self.blocks * self.layers):
 
-            #			 |----------------------------------------|     *residual*
+            #            |----------------------------------------|     *residual*
             #            |                                        |
-            # 			 |	  |-- conv -- tanh --|			      |
+            #            |	  |-- conv -- tanh --|			      |
             # -> dilate -|----|                  * ----|-- 1x1 -- + -->	*input*
-            #				  |-- conv -- sigm --|     |
-            #							              1x1
-            #							               |
+            #                 |-- conv -- sigm --|     |
+            #                                         1x1
+            #                                          |
             # ---------------------------------------> + ------------->	*skip*
 
             (dilation, init_dilation) = self.dilations[i]


### PR DESCRIPTION
On wavenet_model.py, there were some unreadable comments because of the tab, not the space.
So all tabs have been replaced by spaces.